### PR TITLE
Remove keyword `continue` from sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ NuGetPush(packagePath, new NuGetPushSettings {
 ```
 
 ```c#
-var continue = Prompt("Do you want to continue? [Y/N]", "N").Trim().ToUpperInvariant() == "Y";
-if (continue)
+var shouldContinue = Prompt("Do you want to continue? [Y/N]", "N").Trim().ToUpperInvariant() == "Y";
+if (shouldContinue)
+{
     ...
+}
 ```
 
 The `Prompt()` method throws a `TimeoutException` after the supplied timeout duration (Defaults to 30 seconds).


### PR DESCRIPTION
Update the ReadMe.md to change the usage of a reserved keyword `continue` as variable name to `shouldContinue`

Fixes #4 