### PR TITLE
Honour timeout in Prompt(message, defaultResult, timeout)

### DIFF
--- a/src/Cake.Prompt/PromptAliases.cs
+++ b/src/Cake.Prompt/PromptAliases.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -69,21 +68,28 @@ namespace Cake.Common.IO
             if (timeout <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(timeout), "timeout must be greater than zero");
 
-            var cts = new CancellationTokenSource(timeout);
-
-            try
+            // Console.ReadLine() is a blocking synchronous call that ignores
+            // CancellationToken — it returns only when the user presses Enter
+            // or stdin is closed. To honour the timeout we race the read
+            // against Task.Delay(timeout) via Task.WhenAny. If the delay wins
+            // the read task is orphaned and continues blocking in the
+            // background until the user presses Enter or the process exits;
+            // that is unavoidable without P/Invoke or a Console.KeyAvailable
+            // polling loop, and is acceptable for a CI/build-script context.
+            var readTask = Task.Run(() =>
             {
-                return Task.Run(() =>
-                {
-                    Console.Write(string.IsNullOrEmpty(defaultResult) ? message : $"{message} [{defaultResult}]");
-                    var readLine = Console.ReadLine();
-                    return string.IsNullOrEmpty(readLine) ? defaultResult : readLine;
-                }, cts.Token).GetAwaiter().GetResult();
-            }
-            catch (OperationCanceledException)
+                Console.Write(string.IsNullOrEmpty(defaultResult) ? message : $"{message} [{defaultResult}]");
+                var readLine = Console.ReadLine();
+                return string.IsNullOrEmpty(readLine) ? defaultResult : readLine;
+            });
+
+            var winner = Task.WhenAny(readTask, Task.Delay(timeout)).GetAwaiter().GetResult();
+            if (winner != readTask)
             {
                 throw new TimeoutException($"Prompt timed out after {timeout:g}.");
             }
+
+            return readTask.GetAwaiter().GetResult();
         }
     }
 }


### PR DESCRIPTION
Fixes #15.

## Summary

`PromptAliases.Prompt(message, defaultResult, timeout)` was supposed to throw `TimeoutException` if the user didn't respond within `timeout`, but in practice blocked indefinitely on `Console.ReadLine()` and only returned once the user pressed Enter — even well past the configured timeout. This made the `timeout` argument silently inert.

## What was wrong

Two issues stacked in the previous implementation:

1. `Task.Run(action, cancellationToken)` only honours the token for **scheduling**, not for the running task body. Once the task started executing, the token did nothing.
2. `Console.ReadLine()` is a **blocking synchronous call** with no `CancellationToken` overload — it cannot be interrupted by token cancellation. It returns only when the user presses Enter or stdin is closed.

When the timer fired and the token was signalled, the running task kept blocking inside `ReadLine`. `GetAwaiter().GetResult()` kept waiting on the still-running task, the `OperationCanceledException` `catch` was never hit, and `TimeoutException` was never thrown.

## What this changes

Replace the cancellation pattern with a `Task.WhenAny` race between the read task and `Task.Delay(timeout)`:

- If the delay wins → throw `TimeoutException`.
- If the read wins → return its result.

The losing read task is orphaned in the background and keeps blocking until the user presses Enter or the process exits. That's unavoidable without P/Invoke or a `Console.KeyAvailable` polling loop, and is acceptable for a CI/build-script context where Cake exits shortly after.

The unused `using System.Threading;` is removed since `CancellationTokenSource` is no longer used.

## Scope (intentionally narrow)

This PR only touches [src/Cake.Prompt/PromptAliases.cs](https://github.com/cake-contrib/Cake.Prompt/blob/main/src/Cake.Prompt/PromptAliases.cs). The csproj, target frameworks, `Cake.Core` references, and CI workflow are deliberately untouched — TFM modernisation and per-Cake-major catch-up releases (Cake 2.0.0 → 6.0.0) are tracked separately and will land as their own PRs.

## Test plan

- [x] `dotnet build -f net6.0` against the modified source — succeeds with 0 warnings, 0 errors.
- [x] Working-tree `prompt.cake` harness (not committed) calls `Prompt("...", "default", TimeSpan.FromSeconds(3))` with stdin held open via a `sleep 30 | dotnet cake prompt.cake` pipe.
- [x] Result: `TimeoutException` fires at **3020ms** (timeout was 3000ms — a 20ms scheduling margin), task reports `Succeeded`, total elapsed 3.06s. Without the fix, the 30s wall-clock cap would trigger first.

Once merged, gep13 will tag `1.2.2` to drive the NuGet release via the existing `dotnet.yml` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)