### PR TITLE
(#22) Cake.Prompt 5.0.0: Cake 5 catch-up

### DIFF
--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)\</RunWorkingDirectory>
     <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.Prompt">
-      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Prompt\net6.0\Cake.Prompt.dll</HintPath>
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Prompt\net8.0\Cake.Prompt.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="4.2.0" />
+    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "4.2.0",
+            "version": "5.1.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/demo/script/prompt.cake
+++ b/demo/script/prompt.cake
@@ -1,4 +1,4 @@
-#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Prompt/net6.0/Cake.Prompt.dll"
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Prompt/net8.0/Cake.Prompt.dll"
 
 using System;
 using System.Diagnostics;

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "8.0.100",
+      "version": "9.0.100",
       "rollForward": "latestFeature"
     }
   }

--- a/src/Cake.Prompt.Tests/Cake.Prompt.Tests.csproj
+++ b/src/Cake.Prompt.Tests/Cake.Prompt.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);SA1600;SA1633;CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="4.0.0" />
-    <PackageReference Include="Cake.Testing" Version="4.0.0" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" />
+    <PackageReference Include="Cake.Testing" Version="5.0.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.Prompt/Cake.Prompt.csproj
+++ b/src/Cake.Prompt/Cake.Prompt.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Closes #22.

## Summary

Bumps Cake.Prompt from Cake 4 → Cake 5, releasing as **5.0.0** per the per-Cake-major release plan from #17.

## Breaking change

| | 4.0.0 | 5.0.0 |
|---|---|---|
| `Cake.Core` ref | 4.0.0 | **5.0.0** |
| `Cake.Testing` ref | 4.0.0 | **5.0.0** |
| Addin TFMs | `net6.0;net7.0;net8.0` | **`net8.0;net9.0`** (drops net6/7) |
| Tests TFM | `net6.0` | **`net8.0`** |
| `global.json` SDK pin | `8.0.100` | **`9.0.100`** |

Consumers on Cake 4.x must stay on 4.0.0. Consumers on Cake 5.x or later move to 5.0.0+.

## Commits in this PR

1. **`(#22) Bump Cake.Core + Cake.Testing to 5.0.0; TFMs to net8.0;net9.0`** — the actual Cake-5 catch-up content. Includes the `global.json` SDK pin bump (per memory `feedback_global_json_paired_with_tfms` — the SDK major matches the addin's highest TFM); without it the restore step fails with `NETSDK1045 "current .NET SDK does not support targeting .NET 9.0"`.

2. **`(#22) Bump demo runtimes to Cake-5-matching versions`** — `demo/script/.config/dotnet-tools.json` cake.tool 4.2.0 → 5.1.0, `demo/script/prompt.cake` `#reference` path net6.0 → net8.0, `demo/frosting/build/Build.csproj` Cake.Frosting 4.2.0 → 5.1.0, csproj TargetFramework net6.0 → net8.0, HintPath net6.0 → net8.0. `demo/sdk/` stays absent — `Cake.Sdk 5.x` is still beta-only, joins during the Cake 6 catch-up.

## Test plan

- [x] `dotnet cake recipe.cake` (default target) — succeeds, only the expected CCG0009 warnings about Cake.Core 6.0.0 recommendation, 0 errors.
- [x] xunit tests: 7/7 pass via the standard Test target.
- [x] `cd demo/script && dotnet tool restore && dotnet cake prompt.cake` — all 3 sub-tasks pass under cake.tool 5.1.0.
- [x] `cd demo/frosting && dotnet run --project build/Build.csproj` — all 3 sub-tasks pass under Cake.Frosting 5.1.0.
- [x] CI: `build.yml` matrix passes on `windows-2025` and `ubuntu-24.04`, including both demo steps.
- [x] CI: `codeql-analysis.yml` passes.
- [ ] **Post-merge release flow**: cut `release/5.0.0` from develop, merge into main, tag `v5.0.0`. With `masterBranchName: "main"` already in place from #21, the tag-push CI run should fire `Publish-GitHub-Release` end-to-end (NuGet push + GitHub Release + milestone close).

## Migration notes for consumers

```cake
// Cake 4.x consumers — STAY on 4.0.0:
#addin nuget:?package=Cake.Prompt&version=4.0.0

// Cake 5.x+ consumers — bump to 5.0.0:
#addin nuget:?package=Cake.Prompt&version=5.0.0
```

No public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)